### PR TITLE
snapcraft: switch to -updates pocket

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: bluez
-version: 5.72-2-dev
+version: 5.72-3-dev
 type: app
 summary: Bluetooth tools and daemons
 description: |

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -112,7 +112,7 @@ parts:
     plugin: autotools
     source: https://git.launchpad.net/ubuntu/+source/bluez
     source-type: git
-    source-branch: applied/ubuntu/noble
+    source-branch: applied/ubuntu/noble-updates
     autotools-configure-parameters:
       - --prefix=/usr
       - --libexec=/usr/lib/


### PR DESCRIPTION
A bit late, but now that -updates is available, we should use that.