### PR TITLE
backport to snap-20: add serial-port plug to hciattach and btattach

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -42,10 +42,10 @@ apps:
     plugs: [bluetooth-control, network-control, home]
   hciattach:
     command: usr/bin/hciattach
-    plugs: [bluetooth-control]
+    plugs: [bluetooth-control, serial-port]
   btattach:
     command: usr/bin/btattach
-    plugs: [bluetooth-control]
+    plugs: [bluetooth-control, serial-port]
   hcitool:
     command: usr/bin/hcitool
     plugs: [bluetooth-control]


### PR DESCRIPTION
**cherry-pick a commit related to serial-port interface**

The hciattach and btattach tools need to access the serial port which the bluetooth device is connected to. Both tools operate in similar way, they open the serial port and issue a bunch of ioctls() that change the line discipline to N_HCI, set the protocol and speed, which triggers the kernel to create a hciX device for that port.

Fixes: #8