### PR TITLE
Initial upgrade of bluez-snap for core26

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -19,7 +19,7 @@ set -ex
 snap_name=bluez
 cicd_path=cicd
 if [ $# -eq 0 ]
-then set -- google:
+then set -- openstack-dev
 fi
 
 num_snaps=0

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: bluez
-version: 5.72-3-dev
+version: 5.85-4
 type: app
 summary: Bluetooth tools and daemons
 description: |
@@ -7,10 +7,11 @@ description: |
  devices. BlueZ is the official Linux Bluetooth protocol stack. It
  is an Open Source project distributed under GNU General Public
  License (GPL). See the project homepage for more details:
- https://github.com/snapcore/bluez-snap/tree/snap-24
+ https://github.com/canonical/bluez-snap/tree/snap-26
 confinement: strict
-grade: stable
-base: core24
+grade: devel
+base: core26
+build-base: devel
 
 layout:
   /usr/var/lib/bluetooth:
@@ -112,7 +113,7 @@ parts:
     plugin: autotools
     source: https://git.launchpad.net/ubuntu/+source/bluez
     source-type: git
-    source-branch: applied/ubuntu/noble-updates
+    source-branch: applied/ubuntu/resolute-proposed
     autotools-configure-parameters:
       - --prefix=/usr
       - --libexec=/usr/lib/
@@ -123,6 +124,7 @@ parts:
       - --disable-silent-rules
       - --enable-test
       - --enable-deprecated
+      - --with-udevdir=/usr/lib/udev
       # Set explicitly flags until lp: #1791946 is solved
       - CFLAGS='-O2 -Wl,-z,relro,-z,now -pie -fpie'
     build-packages:
@@ -160,5 +162,5 @@ parts:
       # Strip binaries
       find "$CRAFT_PART_INSTALL"/ -executable -type f | xargs file -Ni |
           grep 'application/x-.*executable\|application/x-.*sharedlib' | cut -d: -f1 | xargs strip
-      # Run all tests shiped by default
+      # Run all tests shipped by default
       make check

--- a/spread.yaml
+++ b/spread.yaml
@@ -38,25 +38,40 @@ environment:
   DEFAULT_NETPLAN_FILE: 50-cloud-init.yaml
 
 backends:
-  google:
-    key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
-    location: snapd-spread/us-east1-b
-    plan: n2-standard-2
+  openstack-dev:
+    type: openstack
+    key: '$(HOST: echo "$OS_CREDENTIALS_STG_AMD64_PS7")'
+    plan: shared.xsmall
     halt-timeout: 2h
+    wait-timeout: 10m
+    groups: [default]
+    proxy: ingress-haproxy.ps7.canonical.com
+    cidr-port-rel: [10.151.54.0/24:4000]
+    volume-auto-delete: true
+    environment:
+      SNAPD_USE_PROXY: 'true'
+      HTTP_PROXY: 'http://egress.ps7.internal:3128'
+      HTTPS_PROXY: 'http://egress.ps7.internal:3128'
+      http_proxy: 'http://egress.ps7.internal:3128'
+      https_proxy: 'http://egress.ps7.internal:3128'
+      no_proxy: '127.0.0.1,127.0.0.53,localhost'
+      NO_PROXY: '127.0.0.1,127.0.0.53,localhost'
+      NTP_SERVER: 'ntp.ps7.internal'
     systems:
-      - ubuntu-core-24-64:
-          image: ubuntu-24.04-64
+      - ubuntu-core-26-64:
+          image: ubuntu-26.04-64
           workers: 8
           storage: 20G
     prepare: |
-      # Builds UC image on top of classic 24.04
+      # Builds UC image on top of classic 26.04
       "$TESTSLIB"/prepare-restore.sh --prepare-suite
   qemu:
     memory: 4G
+    environment:
+      DEFAULT_NETPLAN_FILE: 00-snapd-config.yaml
     systems:
-      - ubuntu-core-24:
-          # TODO how is this done in snapd spread?
-          #bios: /usr/share/OVMF/OVMF_CODE.fd
+      - ubuntu-core-26:
+          bios: uefi
           username: test
           password: test
 
@@ -90,9 +105,18 @@ prepare: |
   "$SYSTEMSNAPSTESTLIB"/prepare.sh
 
 prepare-each: |
-  "$SYSTEMSNAPSTESTLIB"/prepare-each.sh "$SNAP_NAME" 24/stable
+  # Wait for seeding before any snap operations
+  snap wait system seed.loaded
+  # OBS: This is temporary to bootstrap. Remove once the snap is published to stable
+  # and leave only the prepare-each.sh command
+  snap install --dangerous "$PROJECT_PATH"/"$SNAP_NAME"*_amd64.snap
+  snap connect bluez:client bluez:service
+  snap connect bluez:uhid
+  # Run prepare-each step which is a bit of a no-op now
+  "$SYSTEMSNAPSTESTLIB"/prepare-each.sh "$SNAP_NAME" 26/stable
 
 restore-each: |
+  snap wait system seed.loaded
   "$SYSTEMSNAPSTESTLIB"/restore-each.sh
 
 debug-each: |

--- a/tests/main/installation/task.yaml
+++ b/tests/main/installation/task.yaml
@@ -1,9 +1,11 @@
 summary: Test bluez snap installation was successful
 
 execute: |
+  . "$SYSTEMSNAPSTESTLIB"/utilities.sh
+
   # Service should be up an running
-  systemctl status snap.bluez.bluez | grep -Pzq ': active'
+  wait_for_systemd_service snap.bluez.bluez
 
   # Ensure all necessary plugs/slots are connected
-  snap interfaces | grep -Pzq "bluez:service +bluez:client"
-  snap interfaces | grep -Pzq ":uhid +bluez"
+  snap connections bluez | grep -Pzq "bluez:client.*bluez:service"
+  snap connections bluez | grep -Pzq "bluez:uhid.*:uhid"


### PR DESCRIPTION
Port the `bluez` snap to the core26 base, tracking the Ubuntu 26.04 (Resolute) package.
@nicoharnois