### PR TITLE
snapcraft.yaml: set grade to stable

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,9 +9,8 @@ description: |
  License (GPL). See the project homepage for more details:
  https://github.com/canonical/bluez-snap/tree/snap-26
 confinement: strict
-grade: devel
+grade: stable
 base: core26
-build-base: devel
 
 layout:
   /usr/var/lib/bluetooth:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -112,7 +112,7 @@ parts:
     plugin: autotools
     source: https://git.launchpad.net/ubuntu/+source/bluez
     source-type: git
-    source-branch: applied/ubuntu/resolute-proposed
+    source-branch: applied/ubuntu/resolute
     autotools-configure-parameters:
       - --prefix=/usr
       - --libexec=/usr/lib/


### PR DESCRIPTION
Set grade to `stable`, remove `build-base` and change `source-branch` from `resolute-proposed` to `resolute`

@nicoharnois @alfonsosanchezbeato @Meulengracht