### PR TITLE
spread.yaml: updates for core26

### DIFF
--- a/.github/workflows/publish_edge.yaml
+++ b/.github/workflows/publish_edge.yaml
@@ -14,5 +14,6 @@ jobs:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         uses: snapcore/system-snaps-cicd-tools/action-publish-edge@main
         with:
+          spread_suites: "openstack:"
           # TODO: remove this filter when snapd 2.64 is released
           architectures: arm64,amd64,armhf

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,5 +12,6 @@ jobs:
           LP_CREDENTIALS: ${{ secrets.LP_CREDENTIALS }}
         uses: snapcore/system-snaps-cicd-tools/action-test@main
         with:
+          spread_suites: "openstack:"
           # TODO: remove this filter when snapd 2.64 is released
           architectures: arm64,amd64,armhf

--- a/spread.yaml
+++ b/spread.yaml
@@ -24,7 +24,7 @@ environment:
   TESTSLIB: $PROJECT_PATH/cicd/snapd-lib
   SYSTEMSNAPSTESTLIB: $PROJECT_PATH/cicd/lib
   TESTSTOOLS: $PROJECT_PATH/cicd/snapd-lib/tools
-  PATH: /snap/bin:$PATH:/var/lib/snapd/snap/bin:$PROJECT_PATH/cicd/snapd-lib/tools
+  PATH: /snap/bin:$PATH:/var/lib/snapd/snap/bin:$PROJECT_PATH/cicd/snapd-lib/tools:/usr/lib/python
   TESTSTMP: /var/tmp/snapd-tools
   REUSE_SNAPD: 0
   SRU_VALIDATION: 0
@@ -38,6 +38,32 @@ environment:
   DEFAULT_NETPLAN_FILE: 50-cloud-init.yaml
 
 backends:
+  openstack:
+    type: openstack
+    key: '$(HOST: echo "$OS_CREDENTIALS_AMD64_PS7")'
+    plan: shared.xsmall
+    halt-timeout: 2h
+    wait-timeout: 10m
+    groups: [default]
+    proxy: ingress-haproxy.ps7.canonical.com
+    cidr-port-rel: [10.151.96.0/21:5000]
+    volume-auto-delete: true
+    environment: &openstack-env
+      SNAPD_USE_PROXY: 'true'
+      HTTP_PROXY: 'http://egress.ps7.internal:3128'
+      HTTPS_PROXY: 'http://egress.ps7.internal:3128'
+      http_proxy: 'http://egress.ps7.internal:3128'
+      https_proxy: 'http://egress.ps7.internal:3128'
+      no_proxy: '127.0.0.1,127.0.0.53,localhost'
+      NO_PROXY: '127.0.0.1,127.0.0.53,localhost'
+      NTP_SERVER: 'ntp.ps7.internal'
+    systems: &openstack-systems
+      - ubuntu-core-26-64:
+          image: snapd-spread/ubuntu-26.04-64-uefi
+          workers: 1
+    prepare: |
+      # Builds UC image on top of classic 26.04
+      "$TESTSLIB"/prepare-restore.sh --prepare-suite
   openstack-dev:
     type: openstack
     key: '$(HOST: echo "$OS_CREDENTIALS_STG_AMD64_PS7")'
@@ -48,20 +74,8 @@ backends:
     proxy: ingress-haproxy.ps7.canonical.com
     cidr-port-rel: [10.151.54.0/24:4000]
     volume-auto-delete: true
-    environment:
-      SNAPD_USE_PROXY: 'true'
-      HTTP_PROXY: 'http://egress.ps7.internal:3128'
-      HTTPS_PROXY: 'http://egress.ps7.internal:3128'
-      http_proxy: 'http://egress.ps7.internal:3128'
-      https_proxy: 'http://egress.ps7.internal:3128'
-      no_proxy: '127.0.0.1,127.0.0.53,localhost'
-      NO_PROXY: '127.0.0.1,127.0.0.53,localhost'
-      NTP_SERVER: 'ntp.ps7.internal'
-    systems:
-      - ubuntu-core-26-64:
-          image: ubuntu-26.04-64
-          workers: 8
-          storage: 20G
+    environment: *openstack-env
+    systems: *openstack-systems
     prepare: |
       # Builds UC image on top of classic 26.04
       "$TESTSLIB"/prepare-restore.sh --prepare-suite
@@ -105,15 +119,10 @@ prepare: |
   "$SYSTEMSNAPSTESTLIB"/prepare.sh
 
 prepare-each: |
-  # Wait for seeding before any snap operations
-  snap wait system seed.loaded
-  # OBS: This is temporary to bootstrap. Remove once the snap is published to stable
-  # and leave only the prepare-each.sh command
-  snap install --dangerous "$PROJECT_PATH"/"$SNAP_NAME"*_amd64.snap
+  # TODO: switch to 26/stable once the snap is promoted there
+  "$SYSTEMSNAPSTESTLIB"/prepare-each.sh "$SNAP_NAME" 26/beta
   snap connect bluez:client bluez:service
   snap connect bluez:uhid
-  # Run prepare-each step which is a bit of a no-op now
-  "$SYSTEMSNAPSTESTLIB"/prepare-each.sh "$SNAP_NAME" 26/stable
 
 restore-each: |
   snap wait system seed.loaded


### PR DESCRIPTION
- use openstack backend for github actions
- use prepare-each.sh to handle snap seeding and installation
- fetch snap from 26/beta channel until it is promoted to stable