### PR TITLE
snapcraft: change service to dbus type and add dbus slot.

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -27,8 +27,9 @@ apps:
     plugs: [client]
   bluez:
     command: bin/bluetoothd-wrapper
-    daemon: simple
-    slots: [service]
+    daemon: dbus
+    bus-name: org.bluez
+    slots: [service, dbus-bluez]
     plugs: [uhid, uinput, kernel-crypto-api]
   obex:
     command: "usr/lib/bluetooth/obexd"
@@ -69,6 +70,10 @@ plugs:
 slots:
   service:
       interface: bluez
+  dbus-bluez:
+      interface: dbus
+      bus: system
+      name: org.bluez
 
 parts:
 


### PR DESCRIPTION
Fixes #27 

It seems dbus is actually used by bluez daemon today in focal, see https://git.launchpad.net/ubuntu/+source/bluez/tree/src/main.c?h=applied/ubuntu/focal-updates#n678

So this PR changes it to be in line with the 22+ snaps, by making the service of type dbus, and adding the dbus slot.

This has been manually built and tested